### PR TITLE
feat(tests): Adding tests for deep tracking changes

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = {
+ extends: ['@commitlint/config-conventional'],
+  // https://commitlint.js.org/#/reference-rules
+  // Level [0..2]: 0 disables the rule. For 1 it will be considered a warning for 2 an error.
+  // Applicable always|never: never inverts the rule.
+  // Value: value to use for this rule.
+  rules: {
+    // 72, the default, is a little short
+    "header-max-length": [1, "always", 100],
+    // Let people use caps
+    "header-case": [0],
+    // Let people write  sentences
+    "header-full-stop": [0],
+    "subject-case": [0],
+  }
+}

--- a/tests/unit/template-test.ts
+++ b/tests/unit/template-test.ts
@@ -175,7 +175,6 @@ module('deep tracked (in templates)', function (hooks) {
             {
               id: 1,
               prop: 'bar',
-
             },
             {
               id: 2,

--- a/tests/unit/tracked-test.ts
+++ b/tests/unit/tracked-test.ts
@@ -116,4 +116,66 @@ module('deep tracked', function (hooks) {
 
     assert.deepEqual(instance.arr, [4, 8]);
   });
+
+  test('array data can be immutably treated', async function (assert) {
+    class Foo {
+      @tracked arr: { id: number; prop: string }[] = [
+        {
+          id: 1,
+          prop: 'foo',
+        },
+        {
+          id: 2,
+          prop: 'bar',
+        },
+        {
+          id: 3,
+          prop: 'baz',
+        },
+      ];
+    }
+
+    let instance = new Foo();
+
+    assert.deepEqual(instance.arr, [
+      {
+        id: 1,
+        prop: 'foo',
+      },
+      {
+        id: 2,
+        prop: 'bar',
+      },
+      {
+        id: 3,
+        prop: 'baz',
+      },
+    ]);
+
+    instance.arr = instance.arr.map((el) => {
+      if (el.id === 2) {
+        return {
+          ...el,
+          prop: 'boink',
+        };
+      }
+
+      return el;
+    });
+
+    assert.deepEqual(instance.arr, [
+      {
+        id: 1,
+        prop: 'foo',
+      },
+      {
+        id: 2,
+        prop: 'boink',
+      },
+      {
+        id: 3,
+        prop: 'baz',
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
I ran into issues with the view not tracking array changes for nested
objects in arrays.  I created simplified tests for these, but could only
prove that these tests worked fine.  It may be worth keeping, or not.