### PR TITLE
Setting a tracked value from undefined to another value will break

### DIFF
--- a/addon/-private/deep-tracked.ts
+++ b/addon/-private/deep-tracked.ts
@@ -66,7 +66,7 @@ function deepTrackedForDescriptor(_obj: object, key: string | symbol, desc: any)
       return readStorage(this, key);
     }
 
-    return initStorage(this, key, deepTracked(initializer.call(this)));
+    return initStorage(this, key, deepTracked(initializer?.call(this)));
   };
 
   desc.set = function set(v: any) {

--- a/tests/unit/tracked-test.ts
+++ b/tests/unit/tracked-test.ts
@@ -68,7 +68,22 @@ module('deep tracked', function (hooks) {
 
       let instance = new Foo();
 
-      assert.notOk(instance.obj);
+      assert.strictEqual(instance.obj, null);
+
+      instance.obj = {};
+      await settled();
+
+      assert.deepEqual(instance.obj, {});
+    });
+
+    test('null to object', async function (assert) {
+      class Foo {
+        @tracked obj: Record<string, any> | null = null;
+      }
+
+      let instance = new Foo();
+
+      assert.strictEqual(instance.obj, null);
 
       instance.obj = {};
       await settled();

--- a/tests/unit/tracked-test.ts
+++ b/tests/unit/tracked-test.ts
@@ -9,55 +9,72 @@ import { tracked } from 'ember-deep-tracked';
 module('deep tracked', function (hooks) {
   setupTest(hooks);
 
-  test('object access', async function (assert) {
-    class Foo {
-      @tracked obj = {} as any;
+  module('Objects', function () {
+    test('object access', async function (assert) {
+      class Foo {
+        @tracked obj = {} as any;
 
-      @cached
-      get objDeep() {
-        return this.obj.foo?.bar;
+        @cached
+        get objDeep() {
+          return this.obj.foo?.bar;
+        }
       }
-    }
 
-    let instance = new Foo();
+      let instance = new Foo();
 
-    assert.notOk(instance.objDeep);
+      assert.notOk(instance.objDeep);
 
-    instance.obj.foo = { bar: 3 };
-    await settled();
-    assert.equal(instance.objDeep, 3);
+      instance.obj.foo = { bar: 3 };
+      await settled();
+      assert.equal(instance.objDeep, 3);
 
-    instance.obj.foo = { bar: 4 };
-    await settled();
-    assert.equal(instance.objDeep, 4);
+      instance.obj.foo = { bar: 4 };
+      await settled();
+      assert.equal(instance.objDeep, 4);
 
-    instance.obj = { foo: { bar: 5 } };
-    await settled();
-    assert.equal(instance.objDeep, 5);
+      instance.obj = { foo: { bar: 5 } };
+      await settled();
+      assert.equal(instance.objDeep, 5);
 
-    instance.obj.foo = { bar: 4 };
-    await settled();
-    assert.equal(instance.objDeep, 4);
-  });
+      instance.obj.foo = { bar: 4 };
+      await settled();
+      assert.equal(instance.objDeep, 4);
+    });
 
-  test('object access in an array', async function (assert) {
-    class Foo {
-      @tracked arr: any[] = [];
+    test('object access in an array', async function (assert) {
+      class Foo {
+        @tracked arr: any[] = [];
 
-      @cached
-      get arrDeep() {
-        return this.arr[0]?.foo?.bar;
+        @cached
+        get arrDeep() {
+          return this.arr[0]?.foo?.bar;
+        }
       }
-    }
 
-    let instance = new Foo();
+      let instance = new Foo();
 
-    assert.notOk(instance.arrDeep);
+      assert.notOk(instance.arrDeep);
 
-    instance.arr.push({ foo: { bar: 2 } });
-    await settled();
+      instance.arr.push({ foo: { bar: 2 } });
+      await settled();
 
-    assert.equal(instance.arrDeep, 2);
+      assert.equal(instance.arrDeep, 2);
+    });
+
+    test('undefined to object', async function (assert) {
+      class Foo {
+        @tracked obj?: Record<string, any>;
+      }
+
+      let instance = new Foo();
+
+      assert.notOk(instance.obj);
+
+      instance.obj = {};
+      await settled();
+
+      assert.deepEqual(instance.obj, {});
+    });
   });
 
   module('Arrays', function () {


### PR DESCRIPTION
I added a failing test. I set this to an object (as this was the case I'm seeing this error pop up). I guess it might also fail, if this would be set to anything else, too (like array or possibly even a primitive).