### PR TITLE
Add failing test

### DIFF
--- a/tests/unit/template-test.ts
+++ b/tests/unit/template-test.ts
@@ -323,11 +323,11 @@ module('deep tracked (in templates)', function (hooks) {
           @tracked arr = [];
 
           get filtered() {
-            return this.arr.filter(item => !item.hide)
+            return this.arr.filter((item) => !item.hide);
           }
 
           add = (item) => this.arr.push({ ...item });
-          remove = (item) => item.hide = true;
+          remove = (item) => (item.hide = true);
         }
 
         this.owner.register(

--- a/tests/unit/tracked-test.ts
+++ b/tests/unit/tracked-test.ts
@@ -131,7 +131,34 @@ module('deep tracked', function (hooks) {
       });
     });
 
-    test('#indexOf', async function (assert) {
+    test('#indexOf works', async function (assert) {
+      assert.expect(2);
+
+      class Foo {
+        @tracked arr = [] as any;
+
+        get item1() {
+          return arr[0];
+        }
+      }
+
+      let instance = new Foo();
+
+      const item1 = { bar: 'baz' };
+      const item2 = { qux: 'norf' };
+
+      instance.arr.push(item1);
+      instance.arr.push(item2);
+
+      let arr = instance.arr;
+      let first = arr.indexOf(instance.item1);
+      let second = arr.indexOf(item2);
+
+      assert.strictEqual(first, 0);
+      assert.strictEqual(second, 0);
+    });
+
+    test('#indexOf works multiple times', async function (assert) {
       assert.expect(2);
 
       class Foo {
@@ -151,6 +178,7 @@ module('deep tracked', function (hooks) {
       assert.strictEqual(first, 0);
       assert.strictEqual(second, 0);
     });
+
   });
 
   test('array data can be re-set', async function (assert) {

--- a/tests/unit/tracked-test.ts
+++ b/tests/unit/tracked-test.ts
@@ -155,7 +155,7 @@ module('deep tracked', function (hooks) {
       let second = arr.indexOf(item2);
 
       assert.strictEqual(first, 0);
-      assert.strictEqual(second, 0);
+      assert.strictEqual(second, 1);
     });
 
     test('#indexOf works multiple times', async function (assert) {


### PR DESCRIPTION
This is an odd one,

Given:
a tracked object with an array `{ array: [] }`
or
a tracked array with objects: `[{ object }]`

and a getter that returns that deep-tracked property....

Neither pushing to the array, or setting a property on the object will cause the getter to recompute.

Sorry I am not sure what to call this PR!